### PR TITLE
Add a postfix queue role

### DIFF
--- a/playbooks/roles/postfix_queue/defaults/main.yml
+++ b/playbooks/roles/postfix_queue/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+
+# postfix_queue: Configure a local postfix server to forward mail to an
+# external SMTP server. This way postfix acts as an outgoing mail queue, and
+# web apps can send mail instantly, while still taking advantage of an
+# external SMTP service.
+#
+# The external service is assumed to use TLS.
+#
+# You must leave the edxapp role's EDXAPP_EMAIL_foo settings at their default
+# values in order for the postfix queue to be used.
+
+POSTFIX_QUEUE_EXTERNAL_SMTP_HOST: ''
+POSTFIX_QUEUE_EXTERNAL_SMTP_PORT: 587
+POSTFIX_QUEUE_EXTERNAL_SMTP_USER: ''
+POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD: ''
+
+
+# Internal vars:
+
+postfix_queue_password_file: "/etc/postfix/sasl/passwd"
+postfix_queue_password_file_hashed: "{{ postfix_queue_password_file }}.db"
+
+postfix_queue_smtp_sasl_auth_enable: "yes"
+postfix_queue_smtp_sasl_password_maps: "hash:{{ postfix_queue_password_file }}"
+postfix_queue_smtp_sasl_mechanism_filter: ""
+postfix_queue_smtp_sasl_security_options: ""
+postfix_queue_relayhost: "{{ POSTFIX_QUEUE_EXTERNAL_SMTP_HOST }}:{{ POSTFIX_QUEUE_EXTERNAL_SMTP_PORT }}"
+postfix_queue_smtp_tls_security_level: "encrypt"
+postfix_queue_smtp_tls_mandatory_ciphers: "high"

--- a/playbooks/roles/postfix_queue/handlers/main.yml
+++ b/playbooks/roles/postfix_queue/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+
+# postfix_queue: Configure a local postfix server to forward mail to an
+# external SMTP server. This way postfix acts as an outgoing mail queue, and
+# web apps can send mail instantly, while still taking advantage of an
+# external SMTP service.
+
+- name: restart postfix
+  service: name=postfix state=restarted

--- a/playbooks/roles/postfix_queue/tasks/main.yml
+++ b/playbooks/roles/postfix_queue/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+
+# postfix_queue: Configure a local postfix server to forward mail to an
+# external SMTP server. This way postfix acts as an outgoing mail queue, and
+# web apps can send mail instantly, while still taking advantage of an
+# external SMTP service.
+
+- name: install postfix
+  apt: pkg=postfix state=present
+
+- name: Backup original postfix main.cf
+  command: cp /etc/postfix/main.cf /etc/postfix/main.cf.backup
+  args:
+    creates: /etc/postfix/main.cf.backup
+
+- name: Configure postfix
+  command: postconf -e '{{ item }}'
+  with_items:
+    - "smtp_sasl_auth_enable = {{ postfix_queue_smtp_sasl_auth_enable }}"
+    - "smtp_sasl_password_maps = {{ postfix_queue_smtp_sasl_password_maps }}"
+    - "smtp_sasl_mechanism_filter = {{ postfix_queue_smtp_sasl_mechanism_filter }}"
+    - "smtp_sasl_security_options = {{ postfix_queue_smtp_sasl_security_options }}"
+    - "relayhost = {{ postfix_queue_relayhost }}"
+    - "smtp_tls_security_level = {{ postfix_queue_smtp_tls_security_level }}"
+    - "smtp_tls_mandatory_ciphers = {{ postfix_queue_smtp_tls_mandatory_ciphers }}"
+  notify: restart postfix
+
+- name: Explain postfix authentication
+  lineinfile: >
+    dest="{{ postfix_queue_password_file }}"
+    line="# configured by ansible:"
+    create=yes
+
+- name: Set permissions of password file
+  file: path="{{ postfix_queue_password_file }}" state=file mode="0600" owner=root group=root
+
+- name: Configure postfix authentication
+  lineinfile: >
+    dest="{{ postfix_queue_password_file }}"
+    line="{{ postfix_queue_relayhost }}    {{ POSTFIX_QUEUE_EXTERNAL_SMTP_USER }}:{{ POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD }}"
+    insertafter="# configured by ansible:"
+  register: postfix_queue_password
+
+- name: Hash postfix SASL password
+  command: "postmap hash:{{ postfix_queue_password_file }}"
+  when: postfix_queue_password.changed
+  notify: restart postfix


### PR DESCRIPTION
This new ansible role will enable edxapp instances to send emails instantly to a postfix server that runs on localhost, and then queues messages and forwards them to a third party SMTP service.

I've tested this role with https://www.authsmtp.com/

**Configuration changes required**:
You need to add this ansible role to the playbook that you're using.

Set these new variables in the secure configuration:

```
POSTFIX_QUEUE_EXTERNAL_SMTP_HOST: mail.authsmtp.com
POSTFIX_QUEUE_EXTERNAL_SMTP_PORT: 2525
POSTFIX_QUEUE_EXTERNAL_SMTP_USER: username_here
POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD: password_here
```

And _unset_ all of the `EDXAPP_EMAIL_` variables in the secure configuration.

You can test with a command like

```
echo -e "Subject: testing a new Rue89 SMTP server\n\nHello" | sendmail -f tech@rue89.com your_email@opencraft.com
```
