### PR TITLE
Revert "Disable http -> https rewrite rules."

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -98,7 +98,7 @@ error_page {{ k }} {{ v }};
 
   # Run our actual redirect...
   if ($do_redirect = "true") {
-    #rewrite ^ https://$host$request_uri? permanent;
+    rewrite ^ https://$host$request_uri? permanent;
   }
 
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
@@ -83,6 +83,6 @@ server {
 
   # Run our actual redirect...
   if ($do_redirect = "true") {
-    #rewrite ^ https://$host$request_uri? permanent;
+    rewrite ^ https://$host$request_uri? permanent;
   }
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -176,6 +176,6 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
 
   # Run our actual redirect...
   if ($do_redirect = "true") {
-    #rewrite ^ https://$host$request_uri? permanent;
+    rewrite ^ https://$host$request_uri? permanent;
   }
 }


### PR DESCRIPTION
This reverts commit f37e5a70a4c102b14f37a07dfa8ad8473d0ab05a.

This change should be deployed once SSL has been set up on the Elastic Load Balancers.
