### PR TITLE
bundle install needs to write to the Gemfile.lock

### DIFF
--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -37,6 +37,15 @@
   register: forum_checkout
   notify: restart the forum service
 
+- name: make Gemfile.lock writable by common_web_user
+  file:
+    path: "{{ forum_code_dir}}/Gemfile.lock"
+    owner: "{{ common_web_user }}"
+  tags:
+    - install
+    - install:code
+    - install:app-requirements
+
 # TODO: This is done as the common_web_user
 # since the process owner needs write access
 # to the rbenv


### PR DESCRIPTION
This pull request cherry-picks a commit from upstream to fix the forum role. Without this fix, the forum role fails with the following error:

```
TASK: [forum | install comments service bundle] *******************************
failed: [XX.XX.XXX.XXX] => {"changed": true, "cmd": "bundle install", "delta": "0:01:53.843507", "end": "2016-05-16 02:57:31.238283", "rc": 5, "start": "2016-05-16 02:55:37.394776", "warnings": []}
...
There was an error while trying to write to Gemfile.lock. It is likely that
you need to allow write permissions for the file at path:
/edx/app/forum/cs_comments_service/Gemfile.lock
```
