### PR TITLE
Don't install edx notes api

### DIFF
--- a/playbooks/rue89_app.yml
+++ b/playbooks/rue89_app.yml
@@ -32,7 +32,6 @@
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - notifier
-    - edx_notes_api
     - oraclejdk
     - forum
     - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }

--- a/playbooks/rue89_stage.yml
+++ b/playbooks/rue89_stage.yml
@@ -32,7 +32,6 @@
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - notifier
-    - edx_notes_api
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - oraclejdk
     - elasticsearch


### PR DESCRIPTION
Due to version compatibility drift, and an inability to specify a branch/ref for edx-notes-api in Rue89's version of the configuration repo, we were unable to install edx-notes-api on new instances.
