### PR TITLE
Eucalyptus updates for analytics

### DIFF
--- a/playbooks/analytics_sandbox.yml
+++ b/playbooks/analytics_sandbox.yml
@@ -11,6 +11,7 @@
   roles:
     - aws
     - security
+    - postfix_queue
     - mysql
     - edxlocal
     - analytics_api

--- a/playbooks/analytics_sandbox.yml
+++ b/playbooks/analytics_sandbox.yml
@@ -1,0 +1,24 @@
+- name: Deploy analytics related services (except the pipeline)
+  hosts: all
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    disable_edx_services: false
+    ENABLE_DATADOG: False
+    ENABLE_SPLUNKFORWARDER: False
+    ENABLE_NEWRELIC: False
+  roles:
+    - aws
+    - security
+    - mysql
+    - edxlocal
+    - analytics_api
+    - role: nginx
+      nginx_sites:
+        - insights
+        - analytics_api
+    - insights
+  tasks:
+    - name: 'Install required packages'
+      apt: name=libffi-dev state=present

--- a/playbooks/analytics_sandbox.yml
+++ b/playbooks/analytics_sandbox.yml
@@ -18,6 +18,7 @@
       nginx_sites:
         - insights
         - analytics_api
+    - oraclejdk
     - insights
   tasks:
     - name: 'Install required packages'

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -23,7 +23,7 @@ http {
         large_client_header_buffers 4 16k;
         # server_tokens off;
 
-        # server_names_hash_bucket_size 64;
+        server_names_hash_bucket_size 128;
         # server_name_in_redirect off;
 
         include /etc/nginx/mime.types;


### PR DESCRIPTION
Starting from the `rue89-eucalyptus` branch, which was rebased from upstream `open-release/eucalyptus.2`:
- 2c06a6d Adds the OpenCraft `analytics_sandbox.yml` playbook, for provisioning a new analytics instance.
- 14539f0 Applies the changes made to the Rue89 fork's old `edx_analytics.yml` to the new `analytics_sandbox.yml`.
- 1bff682 Applies the customizations made to Rue89's old `rue89-analytics` branch.
- b999bc8 Adds the `postfix_queue` role to `analyics_sandbox.yml`, to use Rue89's SMTP provider for sending emails.
